### PR TITLE
Include German language tags in BOT.ttl

### DIFF
--- a/bot/bot.ttl
+++ b/bot/bot.ttl
@@ -16,6 +16,7 @@
         owl:versionInfo "November 23rd 2016"^^xsd:string ;
         dce:modified    "November 23rd 2016"^^xsd:string ;
         rdfs:comment    "The Building Topology Ontology (BOT) is a simple ontology defining the core concepts of a building. BOT should be extended for domain specific purposes such as home automation, indoor navigation, smart cities, etc."@en ,
+						"Die Building Topology Ontology (BOT) ist eine einfach Ontologie, die die wichtigsten Konzepte eines Gebäudes definiert. BOT sollte für spezifische Anwendungen erweitert werden, zum Beispiel Heimautomatisierung, Innenraum Navigation, smart cities, etc."@de ,
                         "BygningsTopologiOntologien (BOT) er en simpel ontologi, som definerer kernekoncepterne i en bygning. BOT bør udvides til fagspecifikke formål som for eksempel home automation, indendørs navigation, smart cities mv."@da ;
         cc:license      <http://creativecommons.org/licenses/by/3.0/> ;
         dce:creator     "Mads Holten Rasmussen (mhoras@byg.dtu.dk)" ,
@@ -33,23 +34,31 @@
 bot:Building a owl:Class ;
         owl:sameAs      dbo:Building ;
         rdfs:label      "Building"@en ,
+						"Gebäude"@de ,
                         "Bygning"@da ;
         rdfs:comment    "An independent unit of the built environment with a characteristic spatial structure, intended to serve at least one function or user activity [ISO 12006-2:2013]"@en ,
+						"Bauwerk hauptsächlich zum Zweck des Schutzes für seine Bewohner und die darin aufbewahrten Gegenstände; im Allgemeinen teilweise oder ganz geschlossen und ortsfest [ISO 6707-1:2014]"@de ,
                         "En uafhængig del af det byggede miljø med en karakteristisk rumlig struktur, der understøtter mindst én funktion eller brugeraktivitet"@da .
 bot:Storey a owl:Class ;
         rdfs:label      "Storey"@en ,
+						"Geschoss (Architektur)"@de ,
                         "Etage"@da ;
         rdfs:comment    "A level part of a building"@en ,
+						"Die Gesamtheit aller Räume in einem Gebäude, die auf einer Zugangsebene liegen und horizontal verbunden sind"@de ,
                         "Et plan i en bygning"@da .
 bot:Element a owl:Class ;
         rdfs:label      "Building element"@en ,
+						"Bauteil (Bauwesen)"@de ,
                         "Bygningsdel"@da ;
         rdfs:comment    "Constituent of a construction entity with a characteristic technical function, form or position [12006-2, 3.4.7]"@en ,
+						"Das Bauteil ist im Bauwesen ein einzelnes Teil, ein Element oder eine Komponente, aus denen ein Bauwerk zusammengesetzt wird"@de ,
                         "Bestanddel af et bygværk med en karakteristisk funktion, form eller position"@da .
 bot:Space a owl:Class ;
         rdfs:label      "Space"@en ,
+						"Raum"@de ,
                         "Rum"@da ;
         rdfs:comment    "A limited three-dimensional extent defined physically or notionally [ISO 12006-2 (DIS 2013), 3.4.3]"@en ,
+						"Fläche oder Volumen mit tatsächlicher oder theoretischer Begrenzung [ISO 6707-1:2014]"@de ,
                         "En afgrænset tredimensionel udstrækning defineret fysisk eller fiktivt"@da .
 
 #################################
@@ -57,36 +66,46 @@ bot:Space a owl:Class ;
 #################################
 bot:hasStorey a owl:ObjectProperty ;
         rdfs:label      "Has storey"@en ,
+						"Hat Geschoss"@de ,
                         "Har etage"@da ;
         rdfs:comment    "Relation to storeys contained in the building."@en ,
+						"Beziehung zu in Gebäude enthaltenden Geschossen"@de ,
                         "Relation til etager indeholdt i bygningen."@da ;
         rdfs:domain     bot:Building ;
         rdfs:range      bot:Storey .
 bot:hasSpace a owl:ObjectProperty ;
         rdfs:label      "Has space"@en ,
+                        "Hat Raum"@de ,
                         "Har rum"@da ;
         rdfs:comment    "Relation to spaces whose plan is located at the storey."@en ,
+						"Beziehung zu Räumen, die sich in einem Geschoss befinden"@de ,
                         "Relation til rum, hvis plan er placeret på etagen."@da ;
         rdfs:domain     bot:Storey ;
         rdfs:range      bot:Space .
 bot:adjacentElement a owl:ObjectProperty ;
         rdfs:label      "Adjacent element"@en ,
+						"Benachbartes Bauteil"@de ,
                         "Tilstødende element"@da ;
         rdfs:comment    "Relation to building elements bounding a physical space"@en ,
+						"Beziehung zu Bauteilen, die einen Raum physisch begrenzen"@de ,
                         "Relation til bygningsdele, som afgrænser et fysisk rum"@da ;
         rdfs:domain     bot:Space ;
         rdfs:range      bot:Element .
 bot:containsElement a owl:ObjectProperty ;
         rdfs:label      "Contained in"@en ,
+                        "Enthalten in"@de ,
                         "Indeholdt i"@da ;
         rdfs:comment    "Relation to a building element contained in a space"@en ,
+                        "Beziehung zu einem Bauteil das in einem Raum enthalten ist"@de ,
                         "Relation til en bygningsdel, som er indeholdt i et rum"@da ;
         rdfs:domain     bot:Space ;
         rdfs:range      bot:Element .
 bot:hasElement a owl:ObjectProperty ;
         rdfs:label      "Has element"@en ,
+                        "Hat Bauteil"@de ,
                         "Har bygningsdel"@da ;
         rdfs:comment    "Relation to elements belonging to a building or a storey."@en ,
+                        "Beziehung eines Bauteils das zu einem Gebäude oder Geschoss gehört"@de ,
                         "Relation til elementer, hørende til en en bygning eller en etage."@da ;
         rdfs:domain     owl:Thing ;
         rdfs:range      bot:Element ;
@@ -129,3 +148,4 @@ inst:Door1 a bot:Element ;
         rdfs:label              "Door 1"@en .
 inst:Table a bot:Element ;
         rdfs:label              "Table"@en .
+		


### PR DESCRIPTION
Proposal fir including German language annotations via rdf:label and rdf:comment in the BOT ontology

-  rdf:label -> used annotations as placed in dbpedia when possible
- rdf:comment -> used definitions from ISO standards when available
- for bot:Storey and bot:Element definitions from dbpedia (cross checked with other sources) used
- for consistency reasons deleted dots (.) at the end of comments
- corrected bot:hasSpace:
rdfs:comment    "Relation to spaces whose plan is located at the storey."@en ,
to 
rdfs:comment    "Relation to spaces whose plane is located at the storey."@en ,

- New file passed consistency check of new file with Protégè 5.1 and HermiT 1.3.8413 with all inference options active